### PR TITLE
Replace Discord link by channel invite

### DIFF
--- a/projects/GETTING_STARTED_DWP.md
+++ b/projects/GETTING_STARTED_DWP.md
@@ -6,8 +6,8 @@ This work is led by @mistermoe. You may engage with our growing community:
 
 | Medium                  | Link                                                                       |
 |-------------------------|----------------------------------------------------------------------------|
-| User Chat               | https://discord.com/channels/937858703112155166/969272658501976117         |
-| Contributor's Chat      | https://discord.com/channels/937858703112155166/981786445696102430         |
+| User Chat               | https://discord.gg/c33Vbn6gPt                                              |
+| Contributor's Chat      | https://discord.gg/FqdAUGMQT5                                              |
 | User Discussions        | https://forums.tbd.website/c/web5-decentralized-web-platform-users/9       |
 | Contributor Discussions | https://forums.tbd.website/c/web5-decentralized-web-platform-developers/10 |
 


### PR DESCRIPTION
Current link only works if you are already member of the server.
New link also works as invite to the server.